### PR TITLE
Host trampolines: Add getenv/setenv

### DIFF
--- a/common/src/include/nsi_host_trampolines.h
+++ b/common/src/include/nsi_host_trampolines.h
@@ -37,6 +37,8 @@ void *nsi_host_realloc(void *ptr, unsigned long size);
 void nsi_host_srandom(unsigned int seed);
 char *nsi_host_strdup(const char *s);
 long nsi_host_write(int fd, const void *buffer, unsigned long size);
+char *nsi_host_getenv(const char *name);
+int nsi_host_setenv(const char *name, const char *value, int overwrite);
 
 #ifdef __cplusplus
 }

--- a/common/src/nsi_host_trampolines.c
+++ b/common/src/nsi_host_trampolines.c
@@ -75,3 +75,13 @@ long nsi_host_write(int fd, const void *buffer, unsigned long size)
 {
 	return write(fd, buffer, size);
 }
+
+char *nsi_host_getenv(const char *name)
+{
+	return getenv(name);
+}
+
+int nsi_host_setenv(const char *name, const char *value, int overwrite)
+{
+	return setenv(name, value, overwrite);
+}


### PR DESCRIPTION
Add trampolines for getenv and setenv to allow to pass data via environment variables.

For reference, this will be used as part of https://github.com/zephyrproject-rtos/zephyr/pull/95603.