### PR TITLE
Host trampolines: add fsync, ftruncate and lseek

### DIFF
--- a/common/src/include/nsi_host_trampolines.h
+++ b/common/src/include/nsi_host_trampolines.h
@@ -26,6 +26,8 @@ void *nsi_host_calloc(unsigned long nmemb, unsigned long size);
 int nsi_host_close(int fd);
 /* void nsi_host_exit (int status); Use nsi_exit() instead */
 void nsi_host_free(void *ptr);
+int nsi_host_fsync(int fd);
+int nsi_host_ftruncate(int fd, long long length);
 char *nsi_host_getcwd(char *buf, unsigned long size);
 char *nsi_host_getenv(const char *name);
 int nsi_host_isatty(int fd);

--- a/common/src/nsi_host_trampolines.c
+++ b/common/src/nsi_host_trampolines.c
@@ -26,6 +26,16 @@ void nsi_host_free(void *ptr)
 	free(ptr);
 }
 
+int nsi_host_fsync(int fd)
+{
+	return fsync(fd);
+}
+
+int nsi_host_ftruncate(int fd, long long length)
+{
+	return ftruncate(fd, length);
+}
+
 char *nsi_host_getcwd(char *buf, unsigned long size)
 {
 	return getcwd(buf, size);


### PR DESCRIPTION
Those trampolines will be used for host FS access.