### PR TITLE
native: hw_timer: add an absolute deadline for the tick interrupt

### DIFF
--- a/native/src/include/nsi_timer_model.h
+++ b/native/src/include/nsi_timer_model.h
@@ -23,6 +23,7 @@ void hwtimer_adjust_rt_ratio(double ratio_correction);
 void hwtimer_wake_in_time(uint64_t time);
 void hwtimer_set_silent_ticks(int64_t sys_ticks);
 void hwtimer_enable(uint64_t period);
+void hwtimer_set_tick_deadline(uint64_t deadline);
 int64_t hwtimer_get_pending_silent_ticks(void);
 
 void hwtimer_reset_rtc(void);

--- a/native/src/timer_model.c
+++ b/native/src/timer_model.c
@@ -65,6 +65,7 @@ static uint64_t hw_timer_timer; /* Event timer exposed to the HW scheduler */
 static uint64_t hw_timer_tick_timer;
 static uint64_t hw_timer_rt_timer;
 static uint64_t hw_timer_awake_timer;
+static uint64_t hw_timer_deadline_timer;
 
 static uint64_t tick_p; /* Period of the ticker */
 static int64_t silent_ticks;
@@ -129,6 +130,7 @@ static void hwtimer_update_timer(void)
 {
 	hw_timer_timer = NSI_MIN(hw_timer_tick_timer, hw_timer_awake_timer);
 	hw_timer_timer = NSI_MIN(hw_timer_timer, hw_timer_rt_timer);
+	hw_timer_timer = NSI_MIN(hw_timer_timer, hw_timer_deadline_timer);
 }
 
 static inline void host_clock_gettime(struct timespec *tv)
@@ -173,6 +175,7 @@ static void hwtimer_init(void)
 	silent_ticks = 0;
 	hw_timer_tick_timer = NSI_NEVER;
 	hw_timer_awake_timer = NSI_NEVER;
+	hw_timer_deadline_timer = NSI_NEVER;
 	hwtimer_update_timer();
 
 	if (!reset_rtc) {
@@ -269,6 +272,13 @@ static void hwtimer_awake_timer_reached(void)
 	hw_irq_ctrl_set_irq(PHONY_HARD_IRQ);
 }
 
+static void hwtimer_deadline_timer_reached(void)
+{
+	hw_timer_deadline_timer = NSI_NEVER;
+	hwtimer_update_timer();
+	hw_irq_ctrl_set_irq(TIMER_TICK_IRQ);
+}
+
 static void hwtimer_timer_reached(void)
 {
 	uint64_t Now = hw_timer_timer;
@@ -279,6 +289,10 @@ static void hwtimer_timer_reached(void)
 
 	if (hw_timer_rt_timer == Now) {
 		hwtimer_rt_timer_reached();
+	}
+
+	if (hw_timer_deadline_timer == Now) {
+		hwtimer_deadline_timer_reached();
 	}
 
 	if (hw_timer_tick_timer == Now) {
@@ -310,6 +324,22 @@ void hwtimer_wake_in_time(uint64_t time)
 		hwtimer_update_timer();
 		nsi_hws_find_next_event();
 	}
+}
+
+/**
+ * Raise the tick interrupt when simulated time reaches <deadline>, an absolute
+ * time in microseconds since boot. A deadline already passed fires at once.
+ * NSI_NEVER cancels without setting a new one.
+ *
+ * One-shot alternative to hwtimer_enable()'s periodic tick. Do not use both.
+ */
+void hwtimer_set_tick_deadline(uint64_t deadline)
+{
+	uint64_t now = nsi_hws_get_time();
+
+	hw_timer_deadline_timer = NSI_MAX(deadline, now);
+	hwtimer_update_timer();
+	nsi_hws_find_next_event();
 }
 
 /**


### PR DESCRIPTION
RFC. Adds a second way to program the tick interrupt: an absolute deadline,
rather than a period plus a count of expiries to skip.

The motivation is fidelity to the hardware being modelled. A free running
counter plus an absolute compare, firing once the counter reaches or passes it,
is what the ARM architected timer (`CNTVCT_EL0` / `CNTV_CVAL_EL0`) and the
RISC-V machine timer (`mtime` / `mtimecmp`) are, and the model already hands out
exactly that counter as `nsi_hws_get_time()`. What it does not expose is the
compare, so a guest driver written for that shape has to convert its deadline
into a count of periods to skip, which rounds it onto the period grid, or
reprogram the period on every timeout so that one period is the delay it wants.

Tested by converting Zephyr's native_sim timer driver to use it, on top of
0d3eafc: `hello_world` paces correctly (`--stop_at=2` in 2 s of wall clock), an
offloaded socket blocking on a peer that replies after 2 real seconds advances
simulated time by 2010 ms, and `tests/kernel` is 2732/2732 on both `native_sim`
and `native_sim/native/64`.

Open questions:

- **Name.** `hwtimer_wake_in_time()` is the existing absolute-time call, so
  `hwtimer_tick_in_time()` would be symmetric. But the semantics differ
  deliberately: `wake_in_time` keeps the earlier of two requests, this one
  replaces.
- **Whether "do not use both" should be enforced rather than documented.**
  `hwtimer_enable()` already clears `silent_ticks` and could clear this too.
